### PR TITLE
Update applicationHost.xdt

### DIFF
--- a/applicationHost.xdt
+++ b/applicationHost.xdt
@@ -14,7 +14,7 @@
     <proxy xdt:Transform="InsertIfMissing" enabled="true" preserveHostHeader="false" reverseRewriteHostInResponseHeaders="false" />  
     <rewrite>
         <allowedServerVariables>
-          <add name="HTTP_ACCEPT_ENCODING" xdt:Transform="Insert" />
+          <add name="HTTP_ACCEPT_ENCODING" xdt:Transform="InsertIfMissing" />
         </allowedServerVariables>
       </rewrite>
   </system.webServer>


### PR DESCRIPTION
Having the <add name="HTTP_ACCEPT_ENCODING" xdt:Transform="Insert" /> causes the entry to always be added, even if another site extension's transform has already added it.